### PR TITLE
Add zenodo metadata for release

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,36 @@
+{
+    "creators": [
+        {
+            "orcid": "0000-0002-2320-4239",
+            "affiliation": "ACCESS-NRI",
+            "name": "Tetley, Michael"
+        },
+        {
+            "orcid": "0000-0003-3271-6874",
+            "affiliation": "ACCESS-NRI",
+            "name": "Squire, Dougal"
+        },
+        {
+            "orcid": "0000-0003-3891-5444",
+            "affiliation": "ACCESS-NRI",
+            "name": "Beucher, Romain"
+        },
+        {
+            "orcid": "0000-0002-4031-8553",
+            "affiliation": "ACCESS-NRI",
+            "name": "Buder, Sven"
+        }
+    ],
+
+    "license": "Apache-2.0",
+
+    "title": "ACCESS-NRI MED Diagnostics",
+
+    "keywords": ["Climate", "Science", "Model Evaluation", "Diagnostics", "Intake", "Intake-ESM", "ACCESS-NRI", "NCI"],
+
+    "communities": [
+        {"identifier": "access-nri"}
+    ],
+
+    "grants": [{"id":""}]
+}


### PR DESCRIPTION
I am adding some metadata for Zenodo on all the MED-related packages.
Please let me know if you are happy to be included or if you think I missed someone.
Also, you can change the order.

We don't have clear directives on who we should add or not. My views are

Main code contributors should go first
People who have participated indirectly in testing, and discussion during the development phase (@dougiesquire )
Maintainers
Other small contributors (bug fixes)
I tend to be quite open as I think the work environment often influences how we do things, but that is my personal opinion.

Thanks!